### PR TITLE
Update station_converter.html

### DIFF
--- a/station_converter.html
+++ b/station_converter.html
@@ -129,12 +129,27 @@ author_profile: false
                 <!-- Input -->
                 <div>
                     <label for="whatsappMessage" class="block text-base font-semibold text-slate-700 mb-2">Plak je WhatsApp bericht hier:</label>
-                    <textarea id="whatsappMessage" class="form-input w-full h-36 border rounded-lg p-3 shadow-sm" placeholder="Bijv. 14:00 Hgl ri Amf" oninput="debounceProcessMessage()"></textarea>
+                    <textarea id="whatsappMessage" class="form-input w-full h-48 md:h-full border rounded-lg p-3 shadow-sm" placeholder="Bijv. 14:00 Hgl ri Amf" oninput="debounceProcessMessage()"></textarea>
                 </div>
                 <!-- Instellingen -->
-                <div>
-                    <label for="targetStationSelect" class="block text-base font-semibold text-slate-700 mb-2">Bereken passage voor:</label>
-                    <select id="targetStationSelect" class="form-input w-full border rounded-lg p-3 shadow-sm bg-white" onchange="processMessage()"></select>
+                <div class="space-y-6">
+                    <div>
+                        <label for="targetStationSelect" class="block text-base font-semibold text-slate-700 mb-2">Bereken passage voor:</label>
+                        <select id="targetStationSelect" class="form-input w-full border rounded-lg p-3 shadow-sm bg-white" onchange="processMessage()"></select>
+                    </div>
+                    <div>
+                        <h3 class="text-base font-semibold text-slate-700 mb-2">Handmatige Goederenpaden</h3>
+                        <div class="grid grid-cols-1 sm:grid-cols-2 gap-4">
+                            <div>
+                                <label for="westboundPathSelect" class="block text-sm font-medium text-slate-600 mb-1">Pad Westwaarts / NL in</label>
+                                <select id="westboundPathSelect" class="form-input w-full border rounded-lg p-3 shadow-sm bg-white text-sm" onchange="processMessage()"></select>
+                            </div>
+                            <div>
+                                <label for="eastboundPathSelect" class="block text-sm font-medium text-slate-600 mb-1">Pad Oostwaarts / NL uit</label>
+                                <select id="eastboundPathSelect" class="form-input w-full border rounded-lg p-3 shadow-sm bg-white text-sm" onchange="processMessage()"></select>
+                            </div>
+                        </div>
+                    </div>
                 </div>
             </div>
             
@@ -234,6 +249,7 @@ author_profile: false
                 });
                 stationData.sort((a, b) => b.afkorting.length - a.afkorting.length);
                 populateStationDropdown();
+                populatePathDropdowns(); // <-- Nieuwe functie aanroepen
 
                 // Parse afstanden
                 const distanceLines = distanceCsvText.trim().split('\n');
@@ -279,6 +295,29 @@ author_profile: false
             });
         }
 
+        // Nieuwe functie om de goederenpad dropdowns te vullen
+        function populatePathDropdowns() {
+            const westSelect = document.getElementById('westboundPathSelect');
+            const eastSelect = document.getElementById('eastboundPathSelect');
+            
+            [westSelect, eastSelect].forEach(select => {
+                select.innerHTML = ''; // Leegmaken
+                const autoOption = document.createElement('option');
+                autoOption.value = 'auto';
+                autoOption.textContent = 'Automatisch';
+                select.appendChild(autoOption);
+
+                for (let i = 0; i <= 29; i++) {
+                    const option = document.createElement('option');
+                    const minute1 = String(i).padStart(2, '0');
+                    const minute2 = String(i + 30).padStart(2, '0');
+                    option.value = i;
+                    option.textContent = `${minute1} / ${minute2}`;
+                    select.appendChild(option);
+                }
+            });
+        }
+
         function toggleParsedData() {
             const dataOutput = document.getElementById('parsed-data-output');
             const toggleBtn = document.getElementById('toggle-data-btn');
@@ -297,6 +336,8 @@ author_profile: false
         function processMessage() {
             const messageInput = document.getElementById('whatsappMessage').value;
             const targetStationName = document.getElementById('targetStationSelect').value;
+            const westPath = document.getElementById('westboundPathSelect').value;
+            const eastPath = document.getElementById('eastboundPathSelect').value;
 
             if (!messageInput.trim()) {
                 clearOutputFields();
@@ -304,7 +345,7 @@ author_profile: false
             }
 
             const parsedData = parseMessage(messageInput);
-            const analysis = analyzeTrajectory(parsedData, targetStationName);
+            const analysis = analyzeTrajectory(parsedData, targetStationName, westPath, eastPath);
             const outputHtml = createHighlightedMessage(parsedData.originalMessage, parsedData.foundMatches);
             displayResults(outputHtml, analysis, parsedData);
         }
@@ -385,7 +426,7 @@ author_profile: false
             return processedMessage;
         }
 
-        function analyzeTrajectory(parsedData, targetStationName) {
+        function analyzeTrajectory(parsedData, targetStationName, westPath, eastPath) {
             const targetStationCode = stationData.find(s => s.naam === targetStationName)?.afkorting;
             let passageHtml = "Geen route herkend in het bericht.";
             let timeHtml = "Geen station of tijdstip gevonden om een berekening te maken.";
@@ -406,14 +447,12 @@ author_profile: false
                 }
                 passageHtml = `Rijrichting: 🚂 <strong>${generalDirection}</strong> | Passage ${targetStationName}: <strong>${passesTarget ? '✅ Ja' : '❌ Nee'}</strong>`;
                 
-                // Bereken de tijd alleen als de trein daadwerkelijk het doelstation passeert.
                 if (passesTarget) {
                     if (parsedData.spotLocation && parsedData.timestamp && targetStationCode) {
                         const firstSpottedStationName = stationData.find(s => s.afkorting === parsedData.spotLocation)?.naam || parsedData.spotLocation;
                         let arrivalTime;
-                        let isSpecialCalc = false;
+                        let timeBlurb = "";
 
-                        // Stap 1: Bereken een ruwe aankomsttijd op basis van afstand en snelheid
                         const distance = distanceData[parsedData.spotLocation]?.[targetStationCode];
                         let roughArrivalDate;
                         if (distance !== undefined) {
@@ -428,73 +467,54 @@ author_profile: false
                         if (!roughArrivalDate) {
                              timeHtml = `<p>Geen afstandsdata gevonden tussen <span class="font-bold">${firstSpottedStationName}</span> en <span class="font-bold">${targetStationName}</span>.</p>`;
                         } else {
-                            // Stap 2: Pas speciale Baarn-logica toe indien van toepassing
-                            let directionForBaarn = null;
-                            if (targetStationName === 'Baarn' && parsedData.spotLocation) {
-                                const spotLocation = parsedData.spotLocation;
-
-                                // Check of de spotlocatie op een aanvoerend traject ligt (richting Amsterdam)
-                                const isFromEastOrSouth = 
-                                    trajectories["Duitsland-Amersfoort"].includes(spotLocation) ||
-                                    trajectories["Amersfoort-Rotterdam"].includes(spotLocation);
-
-                                if (isFromEastOrSouth) {
-                                    directionForBaarn = 'ASD';
-                                } else {
-                                    // Check het Amersfoort-Amsterdam traject voor de specifieke positie
-                                    const amfToAsdTrajectory = trajectories["Amersfoort-Amsterdam"];
-                                    const spotIndex = amfToAsdTrajectory.indexOf(spotLocation);
-                                    const baarnIndex = amfToAsdTrajectory.indexOf(targetStationCode); // targetStationCode is 'BRN'
-
-                                    if (spotIndex !== -1 && baarnIndex !== -1) {
-                                        if (spotIndex < baarnIndex) {
-                                            // Gespot voor Baarn (vanaf Amersfoort), dus rijdt richting Amsterdam
-                                            directionForBaarn = 'ASD'; 
-                                        } else if (spotIndex > baarnIndex) {
-                                            // Gespot na Baarn (vanaf Amsterdam), dus rijdt richting Amersfoort
-                                            directionForBaarn = 'AMF'; 
-                                        }
-                                    }
-                                }
+                            let selectedPathMinute = 'auto';
+                            if (generalDirection === 'Westwaarts' || generalDirection === 'Nederland in') {
+                                selectedPathMinute = westPath;
+                            } else if (generalDirection === 'Oostwaarts' || generalDirection === 'Nederland uit') {
+                                selectedPathMinute = eastPath;
                             }
 
-                            if (directionForBaarn) { // Als een richting voor de speciale Baarn-logica is gevonden
-                                isSpecialCalc = true;
+                            if (selectedPathMinute !== 'auto') {
+                                timeBlurb = " (handmatig goederenpad)";
+                                let arrivalDate = new Date(roughArrivalDate.getTime());
+                                const minute1 = parseInt(selectedPathMinute, 10);
+                                const minute2 = minute1 + 30;
+                                const currentMinutes = arrivalDate.getMinutes();
+
+                                if (currentMinutes <= minute1) {
+                                    arrivalDate.setMinutes(minute1);
+                                } else if (currentMinutes <= minute2) {
+                                    arrivalDate.setMinutes(minute2);
+                                } else {
+                                    arrivalDate.setHours(arrivalDate.getHours() + 1);
+                                    arrivalDate.setMinutes(minute1);
+                                }
+                                arrivalDate.setSeconds(0, 0);
+                                arrivalTime = arrivalDate.toTimeString().substring(0, 5);
+                            } else if (targetStationName === 'Baarn') {
+                                timeBlurb = " (goederenpad Baarn)";
+                                // Existing Baarn logic
                                 let arrivalDate = new Date(roughArrivalDate.getTime());
                                 let targetMinutes;
-                                
-                                if (directionForBaarn === 'AMF') { // Richting Amersfoort (:08 / :38)
-                                    if (arrivalDate.getMinutes() <= 8) {
-                                        targetMinutes = 8;
-                                    } else if (arrivalDate.getMinutes() <= 38) {
-                                        targetMinutes = 38;
-                                    } else {
-                                        targetMinutes = 8;
-                                        arrivalDate.setHours(arrivalDate.getHours() + 1);
-                                    }
-                                    arrivalDate.setMinutes(targetMinutes, 0, 0);
-                                    arrivalTime = arrivalDate.toTimeString().substring(0, 5);
-                                } else if (directionForBaarn === 'ASD') { // Richting Amsterdam (:21 / :51)
-                                    if (arrivalDate.getMinutes() <= 21) {
-                                        targetMinutes = 21;
-                                    } else if (arrivalDate.getMinutes() <= 51) {
-                                        targetMinutes = 51;
-                                    } else {
-                                        targetMinutes = 21;
-                                        arrivalDate.setHours(arrivalDate.getHours() + 1);
-                                    }
-                                    arrivalDate.setMinutes(targetMinutes, 0, 0);
-                                    arrivalTime = arrivalDate.toTimeString().substring(0, 5);
+                                const spotIndex = trajectories["Amersfoort-Amsterdam"].indexOf(parsedData.spotLocation);
+                                const baarnIndex = trajectories["Amersfoort-Amsterdam"].indexOf('BRN');
+                                let directionForBaarn = (spotIndex !== -1 && baarnIndex !== -1 && spotIndex > baarnIndex) ? 'AMF' : 'ASD';
+
+                                if (directionForBaarn === 'AMF') { // :08 / :38
+                                    targetMinutes = (arrivalDate.getMinutes() <= 8 || arrivalDate.getMinutes() > 38) ? 8 : 38;
+                                    if(arrivalDate.getMinutes() > 38) arrivalDate.setHours(arrivalDate.getHours() + 1);
+                                } else { // :21 / :51
+                                    targetMinutes = (arrivalDate.getMinutes() <= 21 || arrivalDate.getMinutes() > 51) ? 21 : 51;
+                                     if(arrivalDate.getMinutes() > 51) arrivalDate.setHours(arrivalDate.getHours() + 1);
                                 }
-                            }
-                            
-                            // Stap 3: Gebruik de ruwe berekening als de speciale logica niet van toepassing was
-                            if (!isSpecialCalc) {
-                                arrivalTime = roughArrivalDate.toTimeString().substring(0, 5);
+                                arrivalDate.setMinutes(targetMinutes, 0, 0);
+                                arrivalTime = arrivalDate.toTimeString().substring(0, 5);
                             }
 
-                            // Stap 4: Genereer de HTML output
-                            const timeBlurb = isSpecialCalc ? " (goederenpad)" : "";
+                            if (!arrivalTime) {
+                                arrivalTime = roughArrivalDate.toTimeString().substring(0, 5);
+                            }
+                            
                             timeHtml = `⏰ Geschatte doorkomsttijd in <span class="font-bold">${targetStationName}</span>${timeBlurb}: <strong class="highlight-estimation">${arrivalTime}</strong> <br> <span class="text-sm text-slate-500">(vanaf ${firstSpottedStationName})</span>`;
                         }
                     } else {


### PR DESCRIPTION
Feature: Handmatige selectie voor goederenpaden

Deze pull request voegt de mogelijkheid toe voor gebruikers om handmatig een specifiek goederenpad (tijdslot) te selecteren voor zowel de westwaartse als oostwaartse rijrichting. Dit geeft meer controle en verhoogt de nauwkeurigheid van de geschatte passage-tijd wanneer een specifiek goederenpad bekend is.

Wijzigingen:

    UI-update: Twee nieuwe dropdown-menu's zijn toegevoegd onder de "Instellingen", één voor "Pad Westwaarts / NL in" en één voor "Pad Oostwaarts / NL uit".

        Elke dropdown bevat opties voor alle halfuurs-tijdsloten (bijv. 01 / 31, 02 / 32, etc.) en een "Automatisch" optie om de standaardberekening te gebruiken.

    Uitbreiding van de berekeningslogica:

        De analyzeTrajectory functie leest nu de geselecteerde waarden uit de nieuwe dropdowns.

        Als een handmatig pad is geselecteerd, wordt de berekende aankomsttijd aangepast aan het eerstvolgende beschikbare moment binnen dat specifieke tijdslot, afhankelijk van de rijrichting.

        De bestaande logica, inclusief de automatische detectie voor station Baarn, blijft functioneren wanneer de selectie op "Automatisch" staat.

    Herberekening: Het wijzigen van een selectie in een van de dropdowns activeert onmiddellijk een herberekening van de passage-tijd.